### PR TITLE
Normalize installed application name

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -13,7 +13,7 @@ SPARKLE_AUTOMATED_DOWNGRADES = 0
 // If your app file on disk is named "MyApp 1.1b4", Sparkle usually updates it
 // in place, giving you an app named 1.1b4 that is actually 1.2. Turn the
 // following on to always reset the name back to "MyApp":
-SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME = 0
+SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME = 1
 
 SPARKLE_VERSION_MAJOR = 1
 SPARKLE_VERSION_MINOR = 24

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -2873,6 +2873,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FA1941CF0D94A70100DD942E /* ConfigCommonDebug.xcconfig */;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
@@ -2881,6 +2882,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FA1941CC0D94A70100DD942E /* ConfigCommonRelease.xcconfig */;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 			};


### PR DESCRIPTION
This patch enables the configuration option `SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME=1`, which allows the app bundle to be renamed.

For information about this option, see https://github.com/sparkle-project/Sparkle/pull/1444
