### PR TITLE
Remove Sparkle's logic to find best valid update

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -215,16 +215,11 @@
             self.nonDeltaUpdateItem = [[updater delegate] bestValidUpdateInAppcast:[ac copyWithoutDeltaUpdates] forUpdater:self.updater];
         }
     }
-    else // If not, we'll take care of it ourselves.
+    else
     {
-        // Find the best supported update
-        SUAppcastItem *deltaUpdateItem = nil;
-        item = [self bestItemFromAppcastItems:ac.items getDeltaItem:&deltaUpdateItem withHostVersion:self.host.version comparator:[self versionComparator]];
-
-        if (item && deltaUpdateItem) {
-            self.nonDeltaUpdateItem = item;
-            item = deltaUpdateItem;
-        }
+        self.updateItem = nil;
+        [self performSelectorOnMainThread:@selector(didNotFindUpdate) withObject:nil waitUntilDone:NO];
+        return;
     }
 
     self.latestAppcastItem = item;


### PR DESCRIPTION
When the delegate method `bestValidUpdate` returns `nil` AppcastItem, Sparkle uses its own logic to find best update. Removing that logic to handle it gracefully